### PR TITLE
fix: create dirs for whole path

### DIFF
--- a/cli/main.go
+++ b/cli/main.go
@@ -43,12 +43,11 @@ func generateBadge(githubActionURL string, branch string, label string) (string,
 }
 
 func ensureDir(dirName string) error {
-    err := os.Mkdir(dirName, os.ModeDir)
-    if err == nil || os.IsExist(err) {
-        return nil
-    } else {
-        return err
-    }
+	if _, err := os.Stat(dirName); os.IsNotExist(err) {
+    err := os.MkdirAll(dirName, os.ModePerm)
+		return err
+	}
+	return nil
 }
 
 func createFile(content []byte, filename string) error {

--- a/cli/main_test.go
+++ b/cli/main_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"io/fs"
+	"os"
 	"testing"
 )
 
@@ -74,7 +75,8 @@ func TestInitWorkflow(t *testing.T) {
 	templates, _ := fs.ReadDir(files, "templates")
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			actualFileName, err := initWorkflow(test.lang, "/tmp/", templates)
+			actualFileName, err := initWorkflow(test.lang, "/tmp/.github/workflows", templates)
+			defer os.RemoveAll("/tmp/.github/workflows")
 			if err != nil {
 				t.Errorf("Error %v", err)
 			}


### PR DESCRIPTION
Fixing `mkdir /tmp/.github/workflows: no such file or directory`